### PR TITLE
Upgrade versions of Eureka Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>se.sawano.eureka</groupId>
     <artifactId>legacy-registrar</artifactId>
-    <version>0.0.7-SNAPSHOT</version>
+    <version>0.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>eureka-legacy-registrar</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>se.sawano.eureka</groupId>
     <artifactId>legacy-registrar</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>eureka-legacy-registrar</name>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.netflix.eureka</groupId>
             <artifactId>eureka-client</artifactId>
-            <version>1.3.4</version>
+            <version>1.4.12</version>
             <exclusions>
                 <exclusion>
                     <!-- Exclude this since it can cause problems as a transitive dependency -->
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.netflix.archaius</groupId>
             <artifactId>archaius-core</artifactId>
-            <version>0.7.1</version>
+            <version>0.7.4</version>
         </dependency>
         <dependency>
             <groupId>se.sawano.java</groupId>

--- a/src/main/java/se/sawano/eureka/legacyregistrar/PropertiesLegacyInstanceConfig.java
+++ b/src/main/java/se/sawano/eureka/legacyregistrar/PropertiesLegacyInstanceConfig.java
@@ -176,6 +176,11 @@ public class PropertiesLegacyInstanceConfig implements LegacyInstanceConfig {
     }
 
     @Override
+    public String[] getDefaultAddressResolutionOrder() {
+        return config.getDefaultAddressResolutionOrder();
+    }
+
+    @Override
     public String getNamespace() {
         return config.getNamespace();
     }

--- a/src/main/java/se/sawano/eureka/legacyregistrar/boot/SpringBootInstanceConfig.java
+++ b/src/main/java/se/sawano/eureka/legacyregistrar/boot/SpringBootInstanceConfig.java
@@ -63,6 +63,7 @@ public class SpringBootInstanceConfig implements LegacyInstanceConfig {
     private String healthCheckUrlPath;
     private String healthCheckUrl;
     private String secureHealthCheckUrl;
+    private String[] defaultAddressResolutionOrder;
     private String namespace;
 
     @Override
@@ -186,6 +187,11 @@ public class SpringBootInstanceConfig implements LegacyInstanceConfig {
     }
 
     @Override
+    public String[] getDefaultAddressResolutionOrder() {
+        return defaultAddressResolutionOrder;
+    }
+
+    @Override
     public String getNamespace() {
         return namespace;
     }
@@ -280,6 +286,10 @@ public class SpringBootInstanceConfig implements LegacyInstanceConfig {
 
     public void setSecureHealthCheckUrl(final String secureHealthCheckUrl) {
         this.secureHealthCheckUrl = secureHealthCheckUrl;
+    }
+
+    public void setDefaultAddressResolutionOrder(final String[] defaultAddressResolutionOrder) {
+        this.defaultAddressResolutionOrder = defaultAddressResolutionOrder;
     }
 
     public void setNamespace(final String namespace) {


### PR DESCRIPTION
- Upgrade version for Eureka Archaius in 0.7.4.
- Upgrade Eureka Client in 1.4.12.

This allow to register legacy applications in a more upgraded version of Eureka Server, and avoid Heartbeat error when registering, like :

`
ERROR c.n.d.p.DiscoveryJerseyProvider - Unexpected error occurred during de-serialization of discovery data, done connection cleanup
ERROR c.netflix.discovery.DiscoveryClient - DiscoveryClient_XXXXX-APP0 - was unable to refresh its cache! status = null
javax.ws.rs.WebApplicationException: null
at com.netflix.discovery.provider.DiscoveryJerseyProvider.readFrom(DiscoveryJerseyProvider.java:110)
at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:634)
at com.sun.jersey.api.client.ClientResponse.getEntity(ClientResponse.java:586)
at com.netflix.discovery.DiscoveryClient.getAndStoreFullRegistry(DiscoveryClient.java:1126)
at com.netflix.discovery.DiscoveryClient.fetchRegistry(DiscoveryClient.java:1029)
at com.netflix.discovery.DiscoveryClient.access$2100(DiscoveryClient.java:123)
`